### PR TITLE
add ability to output metrics in datadog format.

### DIFF
--- a/dbsnap_verify/__init__.py
+++ b/dbsnap_verify/__init__.py
@@ -172,9 +172,7 @@ state_handlers = {
 
 def handler(event):
     """The main entrypoint called from CLI or when our AWS Lambda wakes up."""
-    from sys import stdout
     logger.setLevel(environ.get("LOG_LEVEL", "INFO"))
-    logger.addHandler(logging.StreamHandler(stdout))
     logger.debug("%s", event)
     state_doc = get_or_create_state_doc(event)
     if state_doc is None:

--- a/dbsnap_verify/datadog_output.py
+++ b/dbsnap_verify/datadog_output.py
@@ -1,0 +1,65 @@
+import time
+
+# https://docs.datadoghq.com/integrations/amazon_lambda/#lambda-metrics
+DATADOG_METRIC_TYPES = {"count", "gauge", "histogram", "check"}
+
+# https://github.com/DataDog/datadogpy/blob/master/datadog/api/constants.py
+class CheckStatus(object):
+    OK = 0
+    WARNING = 1
+    CRITICAL = 2
+    UNKNOWN = 3
+    ALL = (OK, WARNING, CRITICAL, UNKNOWN)
+
+
+def now_timestamp():
+    return time.time()
+
+
+def validate_metric_type(metric_type):
+    if metric_type not in DATADOG_METRIC_TYPES:
+        raise Exception(
+            "Invalid datadog metric_type {}, must be {}".format(
+                 metric_type, DATADOG_METRIC_TYPES
+            )
+        )
+
+
+def format_metric_tags(metric_tags):
+    if not metric_tags:
+        return metric_tags
+
+    elif isinstance(metric_tags, list):
+        return "#" + ",".join(metric_tags)
+
+    elif isinstance(metric_tags, dict):
+        return "#" + ",".join(
+            ["{}:{}".format(key, value) for key, value in metric_tags.items()]
+        )
+
+    if not metric_tags.startswith("#"):
+        return "#" + metric_tags
+
+    return metric_tags
+
+
+def datadog_lambda_metric_output(metric_name, metric_value, metric_type="count", metric_tags=""):
+    validate_metric_type(metric_type)
+    return "MONITORING|{}|{}|{}|{}|{}".format(
+        now_timestamp(),
+        metric_value,
+        metric_type,
+        metric_name,
+        format_metric_tags(metric_tags),
+    )
+
+
+def datadog_lambda_check_output(metric_name, metric_value, metric_tags=""):
+    if not isinstance(metric_value, int):
+        metric_value = CheckStatus.__dict__[metric_value]
+    return datadog_lambda_metric_output(
+        metric_name=metric_name,
+        metric_value=metric_value,
+        metric_type="check",
+        metric_tags=metric_tags,
+    )

--- a/dbsnap_verify/datadog_output.py
+++ b/dbsnap_verify/datadog_output.py
@@ -4,6 +4,7 @@ import time
 DATADOG_METRIC_TYPES = {"count", "gauge", "histogram", "check"}
 
 # https://github.com/DataDog/datadogpy/blob/master/datadog/api/constants.py
+# I kept the existing upstream structure to make it easy for future patches.
 class CheckStatus(object):
     OK = 0
     WARNING = 1

--- a/tests/test_datadog_output.py
+++ b/tests/test_datadog_output.py
@@ -1,0 +1,69 @@
+import unittest
+
+from dbsnap_verify.datadog_output import (
+    datadog_lambda_check_output,
+    datadog_lambda_metric_output,
+)
+
+class Tests(unittest.TestCase):
+
+    def test_datadog_check_ok(self):
+        output = datadog_lambda_check_output(
+            metric_name="dbsnap-verify.lambda",
+            metric_value="OK",
+            metric_tags={"database" : "test-db-instance"}
+        )
+        self.assertIn("|#database:test-db-instance", output)
+        self.assertIn("MONITORING|", output)
+        self.assertIn("|0|", output)
+
+    def test_datadog_check_critical(self):
+        output = datadog_lambda_check_output(
+            metric_name="dbsnap-verify.lambda",
+            metric_value="CRITICAL",
+            metric_tags={"database" : "test-db-instance"}
+        )
+        self.assertIn("|#database:test-db-instance", output)
+        self.assertIn("MONITORING|", output)
+        self.assertIn("|2|", output)
+
+    def test_datadog_check_multi_tags(self):
+        output = datadog_lambda_check_output(
+            metric_name="dbsnap-verify.lambda",
+            metric_value="OK",
+            metric_tags={"database" : "test-db-instance", "another" : 3}
+        )
+        self.assertIn("|#database:test-db-instance,another:3", output)
+
+    def test_datadog_check_string_tag(self):
+        output = datadog_lambda_check_output(
+            metric_name="dbsnap-verify.lambda",
+            metric_value="CRITICAL",
+            metric_tags="database:test-db-instance"
+        )
+        self.assertIn("|#database:test-db-instance", output)
+
+    def test_datadog_check_string_tag2(self):
+        output = datadog_lambda_check_output(
+            metric_name="dbsnap-verify.lambda",
+            metric_value="CRITICAL",
+            metric_tags="#database:test-db-instance"
+        )
+        self.assertIn("|#database:test-db-instance", output)
+
+    def test_datadog_check_list_tags(self):
+        output = datadog_lambda_check_output(
+            metric_name="dbsnap-verify.lambda",
+            metric_value="CRITICAL",
+            metric_tags=["database:test-db-instance", "another"]
+        )
+        self.assertIn("|#database:test-db-instance,another", output)
+
+    def test_datadog_output_invalid_metric_type(self):
+        with self.assertRaises(Exception):
+            datadog_lambda_metric_output(
+                metric_name="dbsnap-verify.lambda",
+                metric_type="taco",
+                metric_value=42,
+                metric_tags=["database:test-db-instance", "another"]
+            )


### PR DESCRIPTION
add ability to output metrics in datadog format.

This will be used to monitor and alarm if dbsnap_verify fails to verify a snapshot.	

```
new file:   dbsnap_verify/datadog_output.py
new file:   tests/test_datadog_output.py
```